### PR TITLE
Update GuiHelper.java

### DIFF
--- a/Implementations/Sponge/7/src/main/java/cz/neumimto/rpg/sponge/gui/GuiHelper.java
+++ b/Implementations/Sponge/7/src/main/java/cz/neumimto/rpg/sponge/gui/GuiHelper.java
@@ -552,22 +552,26 @@ public class GuiHelper {
 
         switch (interactiveMode) {
             case FAST:
+                displayTitle = LocalizationKeys.INTERACTIVE_SKILLTREE_MOD_FAST_TITLE;
                 translation = LocalizationKeys.INTERACTIVE_SKILLTREE_MOD_FAST;
                 itemType = ItemTypes.GOLD_NUGGET;
                 break;
             case DETAILED:
+                displayTitle = LocalizationKeys.INTERACTIVE_SKILLTREE_MOD_DETAILS_TITLE;
                 translation = LocalizationKeys.INTERACTIVE_SKILLTREE_MOD_DETAILS;
                 itemType = ItemTypes.BOOK;
                 break;
         }
         LocalizationService localizationService = Rpg.get().getLocalizationService();
-        Text interactiveModeName = TextHelper.parse(localizationService.translate(translation));
+        Text interactiveModeTitle = TextHelper.parse(localizationService.translate(displayTitle));
+        Text interactiveModeSetting = TextHelper.parse(localizationService.translate(translation));
         ItemStack md = itemStack(itemType);
         List<Text> lore = new ArrayList<>();
 
         md.offer(new SkillTreeInventoryViewControllsData(SkillTreeControllsButton.MODE));
         md.offer(new MenuInventoryData(true));
-        lore.add(interactiveModeName);
+        md.offer(Keys.DISPLAY_NAME, Text.of(displayTitle));
+        lore.add(interactiveModeSetting);
         lore.add(Text.EMPTY);
         lore.add(Text.builder("Level: ").color(TextColors.YELLOW)
                 .append(Text.builder(String.valueOf(character.getLevel())).style(TextStyles.BOLD).build())


### PR DESCRIPTION
Add display name translation for the skilltree UI
This will give admins the ability to change the "book" and "gold nugget" icons to whatever they choose.


NOTE:
Have not yet added the translation variables to the ore_localization_<LANGUAGE>properties files as i cannot find them in the repo

Also totally untested cause i can't compile... Please please please make sure i'm not a dummy